### PR TITLE
Configuration option for base64 encoding URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Imgproxy.configure do |config|
   config.hex_key = "your_key"
   # Hex-encoded signature salt
   config.hex_salt = "your_salt"
+
+  # Base64 encode all URLs
+  # config.base64_encode_urls = true
 end
 ```
 
@@ -184,6 +187,7 @@ builder.url_for("http://images.example.com/images/image2.jpg")
 * `preset` — array of names of presets that will be used by imgproxy. See [presets guide](https://github.com/imgproxy/imgproxy/blob/master/docs/presets.md) for more info.
 * `cachebuster` — defines cache buster that doesn't affect image processing but it's changing allows to bypass CDN, proxy server and browser cache.
 * `format` — specifies the resulting image format (`jpg`, `png`, `webp`).
+* `base64_encode_url` — encode the URL as a base64 string.
 * `use_short_options` — per-call redefinition of `use_short_options` config.
 
 **See [imgproxy URL format guide](https://github.com/imgproxy/imgproxy/blob/master/docs/generating_the_url_advanced.md) for more info.**

--- a/lib/imgproxy.rb
+++ b/lib/imgproxy.rb
@@ -77,6 +77,7 @@ module Imgproxy
     # @option options [String] :cachebuster
     # @option options [String] :format
     # @option options [Boolean] :use_short_options
+    # @option options [Boolean] :base64_encode_urls
     # @see https://github.com/DarthSim/imgproxy/blob/master/docs/generating_the_url_advanced.md
     #   imgproxy URL format documentation
     def url_for(image, options = {})

--- a/lib/imgproxy/config.rb
+++ b/lib/imgproxy/config.rb
@@ -17,9 +17,14 @@ module Imgproxy
     #   Defaults to true
     attr_accessor :use_short_options
 
+    # @return [Boolean] base64 encode the URL
+    #   Defaults to false
+    attr_accessor :base64_encode_urls
+
     def initialize
       self.signature_size = 32
       self.use_short_options = true
+      self.base64_encode_urls = false
     end
 
     # Decodes hex-encoded key and sets it to {#key}

--- a/lib/imgproxy/options.rb
+++ b/lib/imgproxy/options.rb
@@ -2,7 +2,7 @@ module Imgproxy
   # Formats and regroups processing options
   class Options < Hash
     STRING_OPTS = %i[resizing_type gravity crop_gravity watermark_position watermark_url style
-                     cachebuster format].freeze
+                     cachebuster format base64_encode_url].freeze
     INT_OPTS = %i[width height crop_width crop_height
                   quality brightness pixelate watermark_x_offset watermark_y_offset].freeze
     FLOAT_OPTS = %i[dpr gravity_x gravity_y crop_gravity_x crop_gravity_y contrast saturation

--- a/spec/imgproxy_spec.rb
+++ b/spec/imgproxy_spec.rb
@@ -37,15 +37,40 @@ RSpec.describe Imgproxy do
 
   subject(:url) { described_class.url_for(src_url, options) }
 
-  it "builds URL" do
-    expect(url).to eq(
-      "http://imgproxy.test/unsafe/"\
-      "c:500:100:ce:0.35:0.65/"\
-      "rs:fill:200:300:1:1/dpr:2.0/g:fp:0.25:0.75/q:80/bg:abcdfe/bl:0.5/"\
-      "sh:0.7/wm:0.5:noea:10:5:0.1/wmu:aHR0cHM6Ly9pbWFnZXMudGVzdC93bS5zdmc/"\
-      "pr:preset1:preset2/cb:qwerty/"\
-      "plain/https://images.test/image.jpg@webp",
-    )
+  describe "builds URL" do
+    context "when plain" do
+      it do
+        expect(url).to eq(
+          "http://imgproxy.test/unsafe/"\
+          "c:500:100:ce:0.35:0.65/"\
+          "rs:fill:200:300:1:1/dpr:2.0/g:fp:0.25:0.75/q:80/bg:abcdfe/bl:0.5/"\
+          "sh:0.7/wm:0.5:noea:10:5:0.1/wmu:aHR0cHM6Ly9pbWFnZXMudGVzdC93bS5zdmc/"\
+          "pr:preset1:preset2/cb:qwerty/"\
+          "plain/https://images.test/image.jpg@webp",
+        )
+      end
+    end
+
+    context "when base64" do
+      around do |ex|
+        described_class.config.base64_encode_urls = true
+
+        ex.run
+
+        described_class.config.base64_encode_urls = false
+      end
+
+      it do
+        expect(url).to eq(
+          "http://imgproxy.test/unsafe/"\
+          "c:500:100:ce:0.35:0.65/"\
+          "rs:fill:200:300:1:1/dpr:2.0/g:fp:0.25:0.75/q:80/bg:abcdfe/bl:0.5/"\
+          "sh:0.7/wm:0.5:noea:10:5:0.1/wmu:aHR0cHM6Ly9pbWFnZXMudGVzdC93bS5zdmc/"\
+          "pr:preset1:preset2/cb:qwerty/"\
+          "#{Base64.urlsafe_encode64(src_url).tr('=', '').scan(/.{1,16}/).join('/')}.webp",
+        )
+      end
+    end
   end
 
   it "builds URL with full processing options names" do
@@ -207,6 +232,17 @@ RSpec.describe Imgproxy do
           "http://imgproxy.test/unsafe/a:10::1.5/plain/https://images.test/image.jpg",
         )
       end
+    end
+  end
+
+  describe "base64_encode_url" do
+    let(:options) { { base64_encode_url: true } }
+
+    it "base64 encodes the URL" do
+      expect(url).to eq(
+        "http://imgproxy.test/unsafe/"\
+        "#{Base64.urlsafe_encode64(src_url).tr('=', '').scan(/.{1,16}/).join('/')}",
+      )
     end
   end
 


### PR DESCRIPTION
Similar to and inspired by #18, but doesn't escape the URL prior to base64 encoding.

+ Adds global config option with appropriate documentation
+ Adds per-URL config option to base64 encode with appropriate documentation
  - Specify omitted options in a more generic manner
+ Properly adds the extension if the format was specified
+ Tests for both global and per-URL encoding